### PR TITLE
cmd/present: serve all content files

### DIFF
--- a/cmd/present/present.go
+++ b/cmd/present/present.go
@@ -24,8 +24,6 @@ var (
 	basePath    = flag.String("base", "", "base path for slide template and static resources")
 )
 
-var License string
-
 func main() {
 	err := flag.CommandLine.Parse(os.Args[1:])
 	if err == flag.ErrHelp {
@@ -40,80 +38,11 @@ func main() {
 		log.Fatalf("Failed to parse templates: %v", err)
 		return
 	}
+	http.Handle("/static/", http.FileServer(http.FS(base)))
 
 	content := os.DirFS(*contentPath)
+	http.Handle("/", presentationServer(content))
 
-	if l, err := fs.ReadFile(content, "LICENSE"); err == nil && !os.IsNotExist(err) {
-		License = string(l)
-	}
-
-	http.Handle("/static/", http.FileServer(http.FS(base)))
-	http.HandleFunc("/", func(resp http.ResponseWriter, req *http.Request) {
-		if req.URL.Path == "/favicon.ico" {
-			http.Redirect(resp, req, "/static/favicon.ico", http.StatusTemporaryRedirect)
-			return
-		}
-
-		upath := strings.TrimPrefix(req.URL.Path, "/")
-		p := path.Clean(upath)
-		if p == "" {
-			p = "."
-		}
-		stat, err := fs.Stat(content, p)
-		if os.IsNotExist(err) {
-			http.NotFound(resp, req)
-			return
-		}
-		if err != nil {
-			http.Error(resp, http.StatusText(500), 500)
-			return
-		}
-		if stat.IsDir() {
-			d := &dirListData{Breadcrumbs: parseBreadcrumbs(upath)}
-
-			files, err := fs.ReadDir(content, p)
-			if err != nil {
-				log.Print(err)
-				http.Error(resp, http.StatusText(500), 500)
-				return
-			}
-			for _, f := range files {
-				fp := path.Join(p, f.Name())
-				e := dirEntry{
-					Name: f.Name(),
-					Path: filepath.ToSlash(fp),
-				}
-				switch {
-				case strings.HasPrefix(f.Name(), "."):
-					// Ignore hidden files
-				case f.IsDir():
-					d.Dirs = append(d.Dirs, e)
-				case strings.HasSuffix(f.Name(), ".slide"):
-					if p, err := parse(content, fp, presenter.TitlesOnly); err != nil {
-						log.Printf("parse(%q, present.TitlesOnly): %v", fp, err)
-					} else {
-						e.Title = p.Title
-					}
-					d.Slides = append(d.Slides, e)
-				}
-			}
-			sort.Sort(d.Dirs)
-			sort.Sort(d.Slides)
-			d.License = License
-			contentTemplates.ExecuteTemplate(resp, "dir.tmpl", d)
-			return
-		} else {
-			d := &presenter.Doc{}
-			if p, err := parse(content, p, 0); err != nil {
-				log.Printf("parse(%q, present.TitlesOnly): %v", p, err)
-			} else {
-				d = p
-			}
-			if err := contentTemplates.ExecuteTemplate(resp, "slides.tmpl", d); err != nil {
-				log.Print(err)
-			}
-		}
-	})
 	scheme := "http"
 	log.Printf("Open your web browser and visit %s://%s", scheme, *httpAddr)
 	if err := http.ListenAndServe(*httpAddr, nil); err != nil {
@@ -166,10 +95,6 @@ func (s dirEntrySlice) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 func (s dirEntrySlice) Less(i, j int) bool { return s[i].Name < s[j].Name }
 
 var (
-	contentTypes = map[string]string{
-		"slide": ".slide",
-	}
-
 	// contentTemplates holds the content templates.
 	contentTemplates *template.Template
 )
@@ -188,4 +113,82 @@ func initTemplates(base fs.FS) error {
 // pageNum derives a page number from a section.
 func pageNum(index int, offset int) int {
 	return index + offset
+}
+
+func presentationServer(content fs.FS) http.Handler {
+	contentFileServer := http.FileServer(http.FS(content))
+
+	var license string
+	if l, err := fs.ReadFile(content, "LICENSE"); err == nil && !os.IsNotExist(err) {
+		license = string(l)
+	}
+
+	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+		if req.URL.Path == "/favicon.ico" {
+			http.Redirect(resp, req, "/static/favicon.ico", http.StatusTemporaryRedirect)
+			return
+		}
+
+		upath := strings.TrimPrefix(req.URL.Path, "/")
+		p := path.Clean(upath)
+		if p == "" {
+			p = "."
+		}
+		stat, err := fs.Stat(content, p)
+		if os.IsNotExist(err) {
+			http.NotFound(resp, req)
+			return
+		}
+		if err != nil {
+			http.Error(resp, http.StatusText(500), 500)
+			return
+		}
+		if stat.IsDir() {
+			d := &dirListData{Breadcrumbs: parseBreadcrumbs(upath)}
+
+			files, err := fs.ReadDir(content, p)
+			if err != nil {
+				log.Print(err)
+				http.Error(resp, http.StatusText(500), 500)
+				return
+			}
+			for _, f := range files {
+				fp := path.Join(p, f.Name())
+				e := dirEntry{
+					Name: f.Name(),
+					Path: filepath.ToSlash(fp),
+				}
+				switch {
+				case strings.HasPrefix(f.Name(), "."):
+					// Ignore hidden files
+				case f.IsDir():
+					d.Dirs = append(d.Dirs, e)
+				case strings.HasSuffix(f.Name(), ".slide"):
+					if p, err := parse(content, fp, presenter.TitlesOnly); err != nil {
+						log.Printf("parse(%q, present.TitlesOnly): %v", fp, err)
+					} else {
+						e.Title = p.Title
+					}
+					d.Slides = append(d.Slides, e)
+				}
+			}
+			sort.Sort(d.Dirs)
+			sort.Sort(d.Slides)
+			d.License = license
+			contentTemplates.ExecuteTemplate(resp, "dir.tmpl", d)
+			return
+		} else if path.Ext(p) == ".slide" {
+			d := &presenter.Doc{}
+			if p, err := parse(content, p, 0); err != nil {
+				log.Printf("parse(%q, present.TitlesOnly): %v", p, err)
+			} else {
+				d = p
+			}
+			if err := contentTemplates.ExecuteTemplate(resp, "slides.tmpl", d); err != nil {
+				log.Print(err)
+			}
+		} else {
+			contentFileServer.ServeHTTP(resp, req)
+		}
+	})
 }


### PR DESCRIPTION
This PR will make cmd/present to serve content files when they are accessed directly. This will allow users to include images in their slides.